### PR TITLE
Pass arguments to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ $ npm install virtual-widget
 const virtualWidget = require('virtual-widget')
 
 module.exports = virtualWidget({
-  init: function () {
+  init: function (state) {
+    this.state = state
     var elem = document.createElement('div')
     this.map = GoogleMap(elem)
     this.map.setPosition(this.state.position)

--- a/index.js
+++ b/index.js
@@ -12,17 +12,19 @@ function virtualWidget (obj) {
   const destroy = obj.destroy || noop
   const render = obj.render || noop
 
-  Widget.prototype.init = init
   Widget.prototype.update = update
   Widget.prototype.destroy = destroy
   Widget.prototype.render = render
 
   return Widget
 
-  function Widget (state) {
-    if (!(this instanceof Widget)) return new Widget(state)
-    assert.equal(typeof state, 'object', 'state should be an object')
+  function Widget () {
+    if (!(this instanceof Widget)) {
+      const o = Object.create(Widget.prototype)
+      o.constructor.apply(o, arguments)
+      return o
+    }
     this.type = 'Widget'
-    this.state = state || {}
+    this.init = init.apply.bind(init, this, arguments)
   }
 }

--- a/test.js
+++ b/test.js
@@ -5,3 +5,16 @@ test('should assert input types', function (t) {
   t.plan(1)
   t.throws(virtualWidget)
 })
+
+test('should pass arguments to init', function (t) {
+  t.plan(4)
+  const Widget = virtualWidget({
+    init: function (a, b) {
+      t.equal(a, 'foo')
+      t.equal(b, 'bar')
+    }
+  })
+  const widget = new Widget('foo', 'bar')
+  widget.init()
+  Widget('foo', 'bar').init()
+})


### PR DESCRIPTION
The use case:

``` js
const myWidget = virtualWidget({
  init (app, state) {
    this.app = app
    this.state = state
  }
})

const app = new App()
app.create({ foo: 'bar' })

function App () {
}

App.prototype.create = function (state) {
  return myWidget(this, state)
}
```

I appreciate this isn't the most elegant solution, but it makes things a lot more flexible.
